### PR TITLE
Change unsims -> unisim in SigasiProjectCreator.py

### DIFF
--- a/SigasiProjectCreator.py
+++ b/SigasiProjectCreator.py
@@ -215,7 +215,7 @@ class SigasiProjectCreator():
 
     def add_unisim(self, unisim_location):
         self.add_link("Common Libraries/unisim", unisim_location, 2)
-        self.add_mapping("Common Libraries/unisim","unisims")
+        self.add_mapping("Common Libraries/unisim", "unisim")
         self.unmap("Common Libraries/unisim/primitive")
         self.unmap("Common Libraries/unisim/secureip")
 


### PR DESCRIPTION
Library is called unisim, although containing folder is named unisims in newer Vivado vesions