### PR TITLE
Fix commonprefix corner-case

### DIFF
--- a/src/ConverterHelper.py
+++ b/src/ConverterHelper.py
@@ -47,7 +47,7 @@ def parse_and_create_project(usage, parse_file):
         if not relative_path.startswith(".."):
             sigasi_project_file_creator.add_mapping(relative_path, library)
         else:
-            common_prefix = os.path.commonprefix([abs_path, abs_destination])
+            common_prefix = os.path.dirname(os.path.commonprefix([p + os.path.sep for p in [abs_path, abs_destination]]))
             eclipse_path = os.path.relpath(abs_path, common_prefix)
             directory_name = get_parts(eclipse_path)[-1]
             target = os.path.join(common_prefix, directory_name)

--- a/src/createSigasiProjectFromListOfFiles.py
+++ b/src/createSigasiProjectFromListOfFiles.py
@@ -29,7 +29,7 @@ def main():
 
     # Find common directory of the hdl files
     abs_paths = [os.path.abspath(x) for x in hdl_files]
-    folder = os.path.commonprefix(abs_paths)
+    folder = os.path.dirname(os.path.commonprefix([p + os.path.sep for p in abs_paths]))
 
     sigasi_project_file_creator = SigasiProjectCreator(project_name, VhdlVersion.NINETY_THREE)
     # Create Project File and add a link the common source folder


### PR DESCRIPTION
This fixes the case when you have two folders in the same hierarchy
that start with the same letter.

e.g. you're invoking convertCsvFileToTree.py from /path/to/module1
where the CSV file contains the link to a file /path/to/my_lib/a.vhd

Before this patch common_prefix would resolve to '/path/to/m' which
would then break further processing.

```
/tmp/SigTest $ cat vivado_files.csv
work , /tmp/Sfoo/a.vhd
/tmp/SigTest $ /path/to/convertCsvFileToTree.py test vivado_files.csv
{'/tmp/Sfoo/a.vhd': 'work'}
Traceback (most recent call last):
  File "/path/to/convertCsvFileToTree.py", line 16, in <module>
    main()
  File "/path/to/convertCsvFileToTree.py", line 12, in main
    ConverterHelper.parse_and_create_project(CsvParser.usage, CsvParser.parse_file)
  File "/path/to/ConverterHelper.py", line 66, in parse_and_create_project
    sigasi_project_file_creator.add_link(folder, location, True)
  File "/path/to/SigasiProjectCreator.py", line 280, in add_link
    self.__projectFileCreator.add_link(name, location, folder)
  File "/path/to/SigasiProjectCreator.py", line 214, in add_link
    raise ValueError('invalid name "' + name + '", a name can not start with dots')
ValueError: invalid name "..", a name can not start with dots
```

Kudos to [1] for this solution.

[1] https://stackoverflow.com/questions/21498939#comment32510708_21499676