### PR TITLE
Make tests compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: '2.7'
+python:
+  - '2.7'
+  - '3.8'
 install:
   - pip install -r requirements.txt
   - pip install --editable .

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ See <http://insights.sigasi.com/manual/projectsetup.html> and <http://insights.s
 
 Run `test.sh` to run the tests.
 Files containing tests have to end in `Test`.
+
+The project and all tests run under both Python 2 and 3.

--- a/src/SigasiProjectCreator/ArgsAndFileParser.py
+++ b/src/SigasiProjectCreator/ArgsAndFileParser.py
@@ -3,8 +3,8 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-from optparse import OptionParser
 import os
+from optparse import OptionParser
 
 
 class ArgsAndFileParser:

--- a/src/SigasiProjectCreator/ConverterHelper.py
+++ b/src/SigasiProjectCreator/ConverterHelper.py
@@ -6,8 +6,9 @@
 import os
 import platform
 import subprocess
-from .SigasiProjectCreator import SigasiProjectCreator
-from .ArgsAndFileParser import ArgsAndFileParser
+
+from SigasiProjectCreator.Creator import SigasiProjectCreator
+from SigasiProjectCreator.ArgsAndFileParser import ArgsAndFileParser
 
 
 def get_parts(pth):

--- a/src/SigasiProjectCreator/ConverterHelper.py
+++ b/src/SigasiProjectCreator/ConverterHelper.py
@@ -6,8 +6,8 @@
 import os
 import platform
 import subprocess
-from SigasiProjectCreator import SigasiProjectCreator
-from ArgsAndFileParser import ArgsAndFileParser
+from .SigasiProjectCreator import SigasiProjectCreator
+from .ArgsAndFileParser import ArgsAndFileParser
 
 
 def get_parts(pth):

--- a/src/SigasiProjectCreator/Creator.py
+++ b/src/SigasiProjectCreator/Creator.py
@@ -170,11 +170,11 @@ ${links}\t</linkedResources>
         self.__add_default_links()
 
     def is_verilog(self):
-        vl_ext = re.compile("\.sv[hi]?$|\.v[h]?$", re.IGNORECASE)
+        vl_ext = re.compile(r"\.sv[hi]?$|\.v[h]?$", re.IGNORECASE)
         return any([vl_ext.search(l[1]) for l in self.__links])
 
     def is_vhdl(self):
-        vhdl_ext = re.compile("\.vhd[l]?$", re.IGNORECASE)
+        vhdl_ext = re.compile(r"\.vhd[l]?$", re.IGNORECASE)
         # VHDL is the default
         return not self.is_verilog() or any([vhdl_ext.search(l[1]) for l in self.__links])
 

--- a/src/SigasiProjectCreator/Creator.py
+++ b/src/SigasiProjectCreator/Creator.py
@@ -3,13 +3,13 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-from string import Template
 import os
 import re
+from string import Template
 
-from . import VhdlVersion
-from . import VerilogVersion
-from . import SettingsFileWriter
+from SigasiProjectCreator import VhdlVersion
+from SigasiProjectCreator import VerilogVersion
+from SigasiProjectCreator import SettingsFileWriter
 
 
 __VERSION_ERROR = Template('''Only ${versions} is/are allowed as ${lang} version number.''')

--- a/src/SigasiProjectCreator/SettingsFileWriter.py
+++ b/src/SigasiProjectCreator/SettingsFileWriter.py
@@ -3,5 +3,5 @@ import os
 
 def write(destination, name, content):
     library_mapping_file = os.path.abspath(os.path.join(destination, name))
-    with open(library_mapping_file, "w") as f:
-        f.write(content)
+    with open(library_mapping_file, "wb") as f:
+        f.write(content.encode())

--- a/src/SigasiProjectCreator/SigasiProjectCreator.py
+++ b/src/SigasiProjectCreator/SigasiProjectCreator.py
@@ -4,11 +4,13 @@
     :license: BSD, see LICENSE for more details.
 """
 from string import Template
-import VhdlVersion
-import VerilogVersion
 import os
 import re
-import SettingsFileWriter
+
+from . import VhdlVersion
+from . import VerilogVersion
+from . import SettingsFileWriter
+
 
 __VERSION_ERROR = Template('''Only ${versions} is/are allowed as ${lang} version number.''')
 

--- a/src/SigasiProjectCreator/convertCsvFileToLinks.py
+++ b/src/SigasiProjectCreator/convertCsvFileToLinks.py
@@ -5,10 +5,11 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
-from . import CsvParser
-from .SigasiProjectCreator import SigasiProjectCreator
-from .ArgsAndFileParser import ArgsAndFileParser
-from . import VhdlVersion
+
+from SigasiProjectCreator.Creator import SigasiProjectCreator
+from SigasiProjectCreator.ArgsAndFileParser import ArgsAndFileParser
+from SigasiProjectCreator import CsvParser
+from SigasiProjectCreator import VhdlVersion
 
 
 def get_file_name(entry):

--- a/src/SigasiProjectCreator/convertCsvFileToLinks.py
+++ b/src/SigasiProjectCreator/convertCsvFileToLinks.py
@@ -22,7 +22,7 @@ def main():
 
     creator = SigasiProjectCreator(project_name, VhdlVersion.NINETY_THREE)
 
-    for path, library in entries.iteritems():
+    for path, library in entries.items():
         file_name = get_file_name(path)
         link_type = os.path.isdir(path)
         creator.add_link(file_name, os.path.abspath(path), link_type)

--- a/src/SigasiProjectCreator/convertCsvFileToLinks.py
+++ b/src/SigasiProjectCreator/convertCsvFileToLinks.py
@@ -5,10 +5,10 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
-import CsvParser
-from SigasiProjectCreator import SigasiProjectCreator
-from ArgsAndFileParser import ArgsAndFileParser
-import VhdlVersion
+from . import CsvParser
+from .SigasiProjectCreator import SigasiProjectCreator
+from .ArgsAndFileParser import ArgsAndFileParser
+from . import VhdlVersion
 
 
 def get_file_name(entry):

--- a/src/SigasiProjectCreator/convertCsvFileToTree.py
+++ b/src/SigasiProjectCreator/convertCsvFileToTree.py
@@ -4,8 +4,8 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-import CsvParser
-import ConverterHelper
+from . import CsvParser
+from . import ConverterHelper
 
 
 def main():

--- a/src/SigasiProjectCreator/convertCsvFileToTree.py
+++ b/src/SigasiProjectCreator/convertCsvFileToTree.py
@@ -4,8 +4,8 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-from . import CsvParser
-from . import ConverterHelper
+from SigasiProjectCreator import CsvParser
+from SigasiProjectCreator import ConverterHelper
 
 
 def main():

--- a/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
+++ b/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
@@ -4,7 +4,7 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 from SigasiProjectCreator import ConverterHelper
 
@@ -16,7 +16,7 @@ example: %prog MyProjectName myproject.hdp
 
 
 def parse_hdp_file(hdp_file):
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(hdp_file)
     entries = config.items("hdl")
     return {lib: path for path, lib in entries}

--- a/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
+++ b/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
@@ -4,8 +4,9 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-import ConfigParser
-from . import ConverterHelper
+from configparser import SafeConfigParser
+
+from SigasiProjectCreator import ConverterHelper
 
 usage = """usage: %prog project-name hdp-file [destination]
 
@@ -15,7 +16,7 @@ example: %prog MyProjectName myproject.hdp
 
 
 def parse_hdp_file(hdp_file):
-    config = ConfigParser.SafeConfigParser()
+    config = SafeConfigParser()
     config.read(hdp_file)
     entries = config.items("hdl")
     return {lib: path for path, lib in entries}

--- a/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
+++ b/src/SigasiProjectCreator/convertHdpProjectToSigasiProject.py
@@ -5,7 +5,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import ConfigParser
-import ConverterHelper
+from . import ConverterHelper
 
 usage = """usage: %prog project-name hdp-file [destination]
 

--- a/src/SigasiProjectCreator/convertXilinxISEToSigasiProject.py
+++ b/src/SigasiProjectCreator/convertXilinxISEToSigasiProject.py
@@ -4,8 +4,9 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-from . import ConverterHelper
 import xml.etree.ElementTree as eT
+
+from SigasiProjectCreator import ConverterHelper
 
 usage = """usage: %prog project-name Xilinx-file [destination]
 

--- a/src/SigasiProjectCreator/convertXilinxISEToSigasiProject.py
+++ b/src/SigasiProjectCreator/convertXilinxISEToSigasiProject.py
@@ -4,7 +4,7 @@
     :copyright: (c) 2008-2017 Sigasi
     :license: BSD, see LICENSE for more details.
 """
-import ConverterHelper
+from . import ConverterHelper
 import xml.etree.ElementTree as eT
 
 usage = """usage: %prog project-name Xilinx-file [destination]

--- a/src/SigasiProjectCreator/createSigasiProjectFromListOfFiles.py
+++ b/src/SigasiProjectCreator/createSigasiProjectFromListOfFiles.py
@@ -5,9 +5,10 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
-from .ArgsAndFileParser import ArgsAndFileParser
-from .SigasiProjectCreator import SigasiProjectCreator
-from . import VhdlVersion
+
+from SigasiProjectCreator.ArgsAndFileParser import ArgsAndFileParser
+from SigasiProjectCreator.Creator import SigasiProjectCreator
+from SigasiProjectCreator import VhdlVersion
 
 usage = """usage: %prog project-name hdl-file hdl-file...
 

--- a/src/SigasiProjectCreator/createSigasiProjectFromListOfFiles.py
+++ b/src/SigasiProjectCreator/createSigasiProjectFromListOfFiles.py
@@ -5,9 +5,9 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
-from ArgsAndFileParser import ArgsAndFileParser
-from SigasiProjectCreator import SigasiProjectCreator
-import VhdlVersion
+from .ArgsAndFileParser import ArgsAndFileParser
+from .SigasiProjectCreator import SigasiProjectCreator
+from . import VhdlVersion
 
 usage = """usage: %prog project-name hdl-file hdl-file...
 

--- a/tests/CreateSigasiProjectFromListOfFilesTest.py
+++ b/tests/CreateSigasiProjectFromListOfFilesTest.py
@@ -34,3 +34,4 @@ class CreateSigasiProjectFromListOfFilesTest(unittest.TestCase):
         sigasiProjectCreator.main()
         result = filecmp.dircmp(list_dir, self.temp_dir)
         self.assertTrue(not result.report())
+        os.chdir(wd)

--- a/tests/LibraryMappingFileCreatorTest.py
+++ b/tests/LibraryMappingFileCreatorTest.py
@@ -5,7 +5,7 @@
 """
 import unittest
 
-from SigasiProjectCreator.SigasiProjectCreator import LibraryMappingFileCreator
+from SigasiProjectCreator.Creator import LibraryMappingFileCreator
 from string import Template
 
 

--- a/tests/ProjectFileCreatorTest.py
+++ b/tests/ProjectFileCreatorTest.py
@@ -5,7 +5,7 @@
 """
 import unittest
 
-from SigasiProjectCreator.SigasiProjectCreator import ProjectFileCreator
+from SigasiProjectCreator.Creator import ProjectFileCreator
 from string import Template
 
 test_template = Template('''<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/SettingsFileWriterTest.py
+++ b/tests/SettingsFileWriterTest.py
@@ -61,4 +61,4 @@ class SettingsFileWriterTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(path))
         with open(path, 'rb') as f:
             read = f.read(content.__len__())
-            self.assertEqual(content, read)
+            self.assertEqual(content, read.decode('utf-8'))

--- a/tests/SigasiProjectCreatorTest.py
+++ b/tests/SigasiProjectCreatorTest.py
@@ -5,10 +5,10 @@
 """
 import unittest
 
-import SigasiProjectCreator.SigasiProjectCreator as sPC
+import SigasiProjectCreator.Creator as sPC
 import SigasiProjectCreator.VerilogVersion as VerilogVersion
 import SigasiProjectCreator.VhdlVersion as VhdlVersion
-from SigasiProjectCreator.SigasiProjectCreator import SigasiProjectCreator
+from SigasiProjectCreator.Creator import SigasiProjectCreator
 
 
 class SigasiProjectCreatorTest(unittest.TestCase):

--- a/tests/SigasiProjectCreatorTest.py
+++ b/tests/SigasiProjectCreatorTest.py
@@ -21,7 +21,7 @@ class SigasiProjectCreatorTest(unittest.TestCase):
             sPC.check_hdl_versions(None, None)
         self.assertTrue(
             '''Only 93, 2002, 2008 is/are allowed as VHDL version number.
-Only v2005 is/are allowed as Verilog version number.''' in exc.exception)
+Only v2005 is/are allowed as Verilog version number.''' == str(exc.exception))
 
     def test_check_hdl_versions_vhdl_none(self):
         sPC.check_hdl_versions(None, VerilogVersion.TWENTY_O_FIVE)
@@ -35,16 +35,16 @@ Only v2005 is/are allowed as Verilog version number.''' in exc.exception)
     def test_check_hdl_versions_vhdl_wrong(self):
         with self.assertRaises(ValueError) as exc:
             sPC.check_hdl_versions(VerilogVersion.TWENTY_O_FIVE, VerilogVersion.TWENTY_O_FIVE)
-        self.assertTrue("Only 93, 2002, 2008 is/are allowed as VHDL version number." in exc.exception)
+        self.assertTrue("Only 93, 2002, 2008 is/are allowed as VHDL version number." == str(exc.exception))
 
     def test_check_hdl_versions_verilog_wrong(self):
         with self.assertRaises(ValueError) as exc:
             sPC.check_hdl_versions(VhdlVersion.NINETY_THREE, VhdlVersion.NINETY_THREE)
-        self.assertTrue("Only v2005 is/are allowed as Verilog version number." in exc.exception)
+        self.assertTrue("Only v2005 is/are allowed as Verilog version number." == str(exc.exception))
 
     def test_check_hdl_versions_both_wrong(self):
         with self.assertRaises(ValueError) as exc:
             sPC.check_hdl_versions(VerilogVersion.TWENTY_O_FIVE, VhdlVersion.NINETY_THREE)
         self.assertTrue(
             '''Only 93, 2002, 2008 is/are allowed as VHDL version number.
-Only v2005 is/are allowed as Verilog version number.''' in exc.exception)
+Only v2005 is/are allowed as Verilog version number.''' == str(exc.exception))


### PR DESCRIPTION
All tests now work with both Python 2 and 3. Some tests were failing on Windows due to issues with line endings and illegal directory removal; this was fixed as well.

The tests were run with Ubuntu Python 2.7, Ubuntu Python 3.8, Windows Python 2.7 and Ubuntu Python 3.7.
All tests pass on these platforms.

closes #18 