### PR TITLE
VUnit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ nosetests.xml
 # Mr Developer
 .mr.developer.cfg
 .project
+.library_mapping.xml
 .pydevproject
 htmlcov
 .idea

--- a/src/SigasiProjectCreator/ConverterHelper.py
+++ b/src/SigasiProjectCreator/ConverterHelper.py
@@ -55,6 +55,7 @@ def parse_and_create_project(usage, parse_file):
 
     forceVHDL = False
     forceVerilog = False
+    forceVUnit = True
 
     linked_folders = dict()
     for path, library in entries.items():
@@ -107,4 +108,4 @@ def parse_and_create_project(usage, parse_file):
             location = convert_cygwin_path(location)
         sigasi_project_file_creator.add_link(folder, location, True)
 
-    sigasi_project_file_creator.write(destination, forceVHDL, forceVerilog, verilog_includes, verilog_defines)
+    sigasi_project_file_creator.write(destination, forceVHDL, forceVerilog, verilog_includes, verilog_defines, forceVUnit)

--- a/src/SigasiProjectCreator/convertCsvFileToLinks.py
+++ b/src/SigasiProjectCreator/convertCsvFileToLinks.py
@@ -29,7 +29,7 @@ def main():
         creator.add_link(file_name, os.path.abspath(path), link_type)
         creator.add_mapping(file_name, library)
 
-    creator.write(destination)
+    creator.write(destination, force_vunit=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added necessary changes for VUnit support to `Creator.py`
- Making sure both `convertCsvFileToLinks.py` and `convertCsvFileToTree.py` enforce writing out VUnit configuration

TODO:

- add command line option(s) for `convertCsvFileToLinks.py` and `convertCsvFileToTree.py` to make VUnit configuration optional